### PR TITLE
Add option to hide posts with 0 comments

### DIFF
--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -30,6 +30,9 @@ class App extends React.Component<AppProps & ReduxProps, {}> {
 	componentWillReceiveProps(nextProps: ReduxProps) {
 		if (location.protocol === "chrome-extension:") return;
 
+		// Remove posts with 0 comments
+		if (this.props.hideZeroCommentPosts) nextProps.posts.splice(0, nextProps.posts.length, ...nextProps.posts.filter(post => post.num_comments > 0))
+
 		// If there are no posts for the next video, switch to YouTube comments.
 		if (!nextProps.postsLoading && nextProps.posts.length === 0) {
 			this.props.push("/youtube");
@@ -73,6 +76,7 @@ export interface AppProps {}
 
 const mapStateToProps = (state: State) => ({
 	default: state.options.default,
+	hideZeroCommentPosts: state.options.hideZeroCommentPosts,
 	path: state.router.location.pathname,
 	posts: state.reddit.posts,
 	postsLoading: state.reddit.postsLoading

--- a/src/data/options/index.ts
+++ b/src/data/options/index.ts
@@ -13,6 +13,7 @@ const initialState: State = {
 	commentSort: "best",
 	default: "reddit",
 	hideYoutubeComments: true,
+	hideZeroCommentPosts: false,
 	postSort: "top"
 };
 

--- a/src/data/options/model.ts
+++ b/src/data/options/model.ts
@@ -2,5 +2,6 @@ export interface State {
 	commentSort: string;
 	default: "youtube" | "reddit";
 	hideYoutubeComments: boolean;
+	hideZeroCommentPosts: boolean;
 	postSort: string;
 }

--- a/src/pages/options/Options.tsx
+++ b/src/pages/options/Options.tsx
@@ -74,6 +74,17 @@ class Options extends React.Component<OptionsProps, {}> {
 					/>
 				</p>
 				<p>
+					<b>{t("hideZeroCommentPosts")}:</b>{" "}
+					<input
+						type="checkbox"
+						onChange={this.onChange.bind(
+							null,
+							"hideZeroCommentPosts"
+						)}
+						checked={options.hideZeroCommentPosts}
+					/>
+				</p>
+				<p>
 					<b>{t("postSort")}:</b>{" "}
 					<select
 						onChange={this.onChange.bind(null, "postSort")}

--- a/src/translations/en/options.json
+++ b/src/translations/en/options.json
@@ -3,5 +3,6 @@
 	"commentSort": "Sort comments by",
 	"default": "Show comments from (default)",
 	"hideYoutubeComments": "Hide YouTube comments by default",
+	"hideZeroCommentPosts": "Hide posts with 0 comments",
 	"postSort": "Sort posts by"
 }


### PR DESCRIPTION
Created a new boolean option to enable hiding posts with 0 comments, re: issue #20 
